### PR TITLE
Avoid extra tabs in code examples

### DIFF
--- a/example.go
+++ b/example.go
@@ -86,7 +86,6 @@ func (p *myPres) exampleMDFunc(info *godoc.PageInfo, funcName, indent string) st
 			code = strings.Replace(code, "\n    ", "\n", -1)
 		}
 		code = strings.Trim(code, "\n")
-		code = strings.Replace(code, "\n", "\n\t", -1)
 
 		buf.WriteString(indent)
 		buf.WriteString("Example:\n\n")


### PR DESCRIPTION
Here's the diff in generated code - it removes the extra tabs

  ```go
  list := []int{2, 3, 4, 6, 8, 2}
 -   fmt.Println(Index(len(list), func(i int) bool { return i%2 == 1 }))
 -   // Output: 1
 +fmt.Println(Index(len(list), func(i int) bool { return i%2 == 1 }))
 +// Output: 1
  ```