### PR TITLE
Treat codegen comments as blank lines

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -242,7 +242,7 @@ func blocks(text string) []block {
 	unindent(lines)
 	for i := 0; i < len(lines); {
 		line := lines[i]
-		if isBlank(line) {
+		if isBlank(line) || strings.HasPrefix(line, "Code generated") {
 			// close paragraph
 			close()
 			i++


### PR DESCRIPTION
Skip codegen comments when doing godoc2ghmd so that we can lift them above the package declaration where they're supposed to be.

Tested by building locally, then running this on a branch where they've been lifted